### PR TITLE
updated config format

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -35,7 +35,7 @@ EOF
         #Change the default port as this is going to be executed without root privileges
         #Also disable IPv6 port bind as it is not enabled by default
         sed -i \
-            "s/listen_addresses = \\['127.0.0.1:53', '\\[::1\\]:53'\\]/listen_addresses = ['0.0.0.0:5353']/" \
+            "s/listen_addresses = \\['127.0.0.1:53'\\]/listen_addresses = ['0.0.0.0:5353']/" \
             "$CONFIG_PATH/dnscrypt-proxy.toml"
 
         #Store the cache of public resolvers in a subfolder


### PR DESCRIPTION
Default config from /usr/local/share/dnscrypt-proxy/ has a different value for the listen_addresses so this fixes the entrypoint.sh
See issue https://github.com/melchor629/docker-dnscrypt-proxy/issues/2 